### PR TITLE
Fix profile image sizing issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -96,6 +96,7 @@ p {
   width: 110px;
   height: 110px;
   margin-left: 15px;
+  flex-shrink: 0;
   /* border-radius: 55px;
   -webkit-border-radius: 55px;
   -moz-border-radius: 55px; */


### PR DESCRIPTION
Set `flex-shrink: 0` to prevent resizing of the profile image.